### PR TITLE
bug fix.h

### DIFF
--- a/include/cagesearch.h
+++ b/include/cagesearch.h
@@ -35,7 +35,7 @@ public:
     void output_color_pattern(int numaddons, std::vector<std::vector<int>> &colpair);
     void output_color_pattern(int numaddons, std::ofstream &output_color_pattern_to_file);
 };
-void stringtograph(std::string s, graph *g, int m);
+static void stringtograph(std::string s, graph *g, int m);
 int graphsize(std::string s);
 static void gt_abort(char *msg);
 static int scan_console(int level, graph *g, _Boolean digraph, int *prev, long minedges, long maxedges, long sofar, long numcols, grouprec *group, int m, int n);


### PR DESCRIPTION
stringtograph is used as static function in cagesearch.cpp, but it is declared as a extern function. This will cause error when compiling.